### PR TITLE
Fix decompression of data with multple meta-blocks

### DIFF
--- a/dec/decode.js
+++ b/dec/decode.js
@@ -582,11 +582,11 @@ function BrotliDecompressBuffer(buffer, output_size) {
   
   BrotliDecompress(input, output);
   
-  if (output.pos < output_buffer.length) {
-    output_buffer = output_buffer.subarray(0, output.pos);
+  if (output.pos < output.buffer.length) {
+    output.buffer = output.buffer.subarray(0, output.pos);
   }
   
-  return output_buffer;
+  return output.buffer;
 }
 
 exports.BrotliDecompressBuffer = BrotliDecompressBuffer;
@@ -675,6 +675,12 @@ function BrotliDecompress(input, output) {
     
     var _out = DecodeMetaBlockLength(br);
     meta_block_remaining_len = _out.meta_block_length;
+    if (output.pos + meta_block_remaining_len > output.buffer.length) {
+      /* We need to grow the output buffer to fit the additional data. */
+      var tmp = new Uint8Array( output.pos + meta_block_remaining_len );
+      tmp.set( output.buffer );
+      output.buffer = tmp;
+    }    
     input_end = _out.input_end;
     is_uncompressed = _out.is_uncompressed;
     

--- a/dec/decode.js
+++ b/dec/decode.js
@@ -675,9 +675,9 @@ function BrotliDecompress(input, output) {
     
     var _out = DecodeMetaBlockLength(br);
     meta_block_remaining_len = _out.meta_block_length;
-    if (output.pos + meta_block_remaining_len > output.buffer.length) {
+    if (pos + meta_block_remaining_len > output.buffer.length) {
       /* We need to grow the output buffer to fit the additional data. */
-      var tmp = new Uint8Array( output.pos + meta_block_remaining_len );
+      var tmp = new Uint8Array( pos + meta_block_remaining_len );
       tmp.set( output.buffer );
       output.buffer = tmp;
     }    
@@ -727,7 +727,8 @@ function BrotliDecompress(input, output) {
     context_modes = new Uint8Array(num_block_types[0]);
 
     for (i = 0; i < num_block_types[0]; ++i) {
-      context_modes[i] = (br.readBits(2) << 1);
+       br.readMoreInput();
+       context_modes[i] = (br.readBits(2) << 1);
     }
     
     var _o1 = DecodeContextMap(num_block_types[0] << kLiteralContextBits, br);
@@ -790,6 +791,8 @@ function BrotliDecompress(input, output) {
           br.readBits(Prefix.kInsertLengthPrefixCode[insert_code].nbits);
       copy_length = Prefix.kCopyLengthPrefixCode[copy_code].offset +
           br.readBits(Prefix.kCopyLengthPrefixCode[copy_code].nbits);
+      prev_byte1 = ringbuffer[pos-1 & ringbuffer_mask];
+      prev_byte2 = ringbuffer[pos-2 & ringbuffer_mask];
       for (j = 0; j < insert_length; ++j) {
         br.readMoreInput();
 


### PR DESCRIPTION
Currently, brotli.js decompression seems to fail for me for input data with multiple meta-blocks if no output_size is specified. This is because BrotliDecompressBuffer calculates output_size from the first meta block, but that will be too small if there are multiple meta blocks. This PR changes this to resize the output buffer when another meta block is found, and the output buffer size is too small to fit it's contents.